### PR TITLE
[ADDED] 跳转到搜索结果笔记时, 使用只读模式

### DIFF
--- a/src/vmainwindow.cpp
+++ b/src/vmainwindow.cpp
@@ -1418,6 +1418,10 @@ void VMainWindow::initSearchDock()
 //    m_searchDock->setAllowedAreas(Qt::AllDockWidgetAreas);
 
     m_searchDock = new VSearcher(this);
+    connect(m_searchDock, &VSearcher::locateDoubleClickedItem,
+        m_findReplaceDialog, [this](QString text) {
+            m_findReplaceDialog->openDialog(text);
+        });
 //    m_searchDock->setObjectName("SearchDock");
 
 //    m_searchDock->setWidget(m_searcher);

--- a/src/vmainwindow.cpp
+++ b/src/vmainwindow.cpp
@@ -2509,7 +2509,7 @@ void VMainWindow::handleFindDialogTextChanged(const QString &p_text, uint /* p_o
 
 void VMainWindow::openFindDialog()
 {
-    m_findReplaceDialog->openDialog(m_editArea->getSelectedText());
+    m_findReplaceDialog->openDialog();
 }
 
 void VMainWindow::viewSettings()

--- a/src/vsearcher.cpp
+++ b/src/vsearcher.cpp
@@ -222,6 +222,10 @@ void VSearcher::setupUI()
                 m_clearBtn->setEnabled(p_count > 0);
                 updateNumLabel(p_count);
             });
+    connect(m_results, &VSearchResultTree::locateDoubleClickedItem,
+            this, [this](QString text) {
+                emit locateDoubleClickedItem(text);
+            });
 
     QShortcut *expandShortcut = new QShortcut(QKeySequence(Shortcut::c_expand), this);
     expandShortcut->setContext(Qt::WidgetWithChildrenShortcut);

--- a/src/vsearcher.cpp
+++ b/src/vsearcher.cpp
@@ -110,8 +110,8 @@ void VSearcher::setupUI()
     m_keywordCB->lineEdit()->setProperty("EmbeddedEdit", true);
     connect(m_keywordCB, &QComboBox::currentTextChanged,
             this, &VSearcher::handleInputChanged);
-    connect(m_keywordCB->lineEdit(), &QLineEdit::returnPressed,
-            this, &VSearcher::animateSearchClick);
+//    connect(m_keywordCB->lineEdit(), &QLineEdit::returnPressed,
+//            this, &VSearcher::animateSearchClick);
     m_keywordCB->completer()->setCaseSensitivity(Qt::CaseSensitive);
 
     // Scope.

--- a/src/vsearcher.cpp
+++ b/src/vsearcher.cpp
@@ -221,6 +221,7 @@ void VSearcher::setupUI()
             this, [this](int p_count) {
                 m_clearBtn->setEnabled(p_count > 0);
                 updateNumLabel(p_count);
+                m_results->expandCollapseAll();     // append 时, 触发信号: countChanged
             });
     connect(m_results, &VSearchResultTree::locateDoubleClickedItem,
             this, [this](QString text) {

--- a/src/vsearcher.h
+++ b/src/vsearcher.h
@@ -36,6 +36,9 @@ protected:
 
     void changeEvent(QEvent *p_event) Q_DECL_OVERRIDE;
 
+signals:
+    void locateDoubleClickedItem(QString text);
+
 private slots:
     void handleSearchFinished(const QSharedPointer<VSearchResult> &p_result);
 

--- a/src/vsearchresulttree.cpp
+++ b/src/vsearchresulttree.cpp
@@ -272,7 +272,7 @@ const QSharedPointer<VSearchResultItem> &VSearchResultTree::itemResultData(const
     return m_data[idx];
 }
 
-void VSearchResultTree::activateItem(const QTreeWidgetItem *p_item) const
+void VSearchResultTree::activateItem(const QTreeWidgetItem *p_item)
 {
     if (!p_item) {
         return;
@@ -280,6 +280,7 @@ void VSearchResultTree::activateItem(const QTreeWidgetItem *p_item) const
 
     VSearchUE::activateItem(itemResultData(p_item), VTreeWidget::childIndexOfTreeItem(p_item));
     parentWidget() -> setVisible(false);
+    emit locateDoubleClickedItem(itemResultData(p_item)->m_config->m_contentToken.m_keywords[0]);
 }
 
 void VSearchResultTree::expandCollapseAll()

--- a/src/vsearchresulttree.cpp
+++ b/src/vsearchresulttree.cpp
@@ -279,6 +279,7 @@ void VSearchResultTree::activateItem(const QTreeWidgetItem *p_item) const
     }
 
     VSearchUE::activateItem(itemResultData(p_item), VTreeWidget::childIndexOfTreeItem(p_item));
+    parentWidget() -> setVisible(false);
 }
 
 void VSearchResultTree::expandCollapseAll()

--- a/src/vsearchresulttree.h
+++ b/src/vsearchresulttree.h
@@ -29,6 +29,8 @@ public slots:
 signals:
     void countChanged(int p_count);
 
+    void locateDoubleClickedItem(QString text);
+
 private slots:
     void locateCurrentItem();
 
@@ -41,7 +43,7 @@ private:
 
     VSearchResultItem::ItemType itemResultType(const QTreeWidgetItem *p_item) const;
 
-    void activateItem(const QTreeWidgetItem *p_item) const;
+    void activateItem(const QTreeWidgetItem *p_item);
 
     const QSharedPointer<VSearchResultItem> &itemResultData(const QTreeWidgetItem *p_item) const;
 

--- a/src/vsearchue.cpp
+++ b/src/vsearchue.cpp
@@ -928,7 +928,7 @@ void VSearchUE::activateItem(const QSharedPointer<VSearchResultItem> &p_item, in
         }
 
         QStringList files(p_item->m_path);
-        OpenFileMode mode = highlightPage ? OpenFileMode::Edit : OpenFileMode::Read;
+        OpenFileMode mode = OpenFileMode::Read;
         bool forceMode = highlightPage;
         QVector<VFile *> openedFiles = g_mainWin->openFiles(files,
                                                             false,


### PR DESCRIPTION
* [ADDED] 跳转到搜索结果笔记时, 使用只读模式

* [ADDED] 跳转到笔记后, 关闭搜索框

* [ADDED] 选中文字后, 弹出搜索框不带上文字

* [ADDED] 修复搜索框改为QDialog后, 回车触发搜索两次的问题

* [ADDED] 双击高级搜索结果时, 跳转后自动打开普通搜索

* [ADDED] 自动拓展搜索结果树